### PR TITLE
Bugfix: Don't strip newlines from shaders

### DIFF
--- a/opengl/main.rkt
+++ b/opengl/main.rkt
@@ -383,7 +383,7 @@
       (bytes->string/utf-8 info-log #\? 0 actual-length))))
 
 (define (load-shader-source shader port)
-  (let* ((lines (for/vector ((line (in-lines port))) line))
+  (let* ((lines (for/vector ((line (in-lines port))) (string-append line "\n")))
          (sizes (for/list ((line (in-vector lines))) (string-length line)))
          (sizes (list->s32vector sizes)))
    (glShaderSource shader (vector-length lines) lines sizes)))


### PR DESCRIPTION
When using `(load-shader)` to compile shaders, the `(in-lines port)` generates a sequence of strings but each string doesn't have the newline at the end. Unfortunately, this causes shaders with `#version` preprocessing directives or comments to fail.

This patch adds the newlines back in.
