### PR TITLE
added missing package dependency

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,5 +1,5 @@
 #lang setup/infotab
 
 (define collection 'multi)
-(define deps '("base" "draw-lib" "scribble-lib"))
+(define deps '("base" "draw-lib" "scribble-lib" "srfi-lite-lib"))
 (define build-deps '("draw-doc" "gui-doc" "gui-lib" "racket-doc"))


### PR DESCRIPTION
a 'make in-place' from the main racket repo will error if this package is install:

raco setup: found undeclared dependency:
raco setup:   mode: run
raco setup:   for package: "opengl"
raco setup:   on package: "srfi-lite-lib"
raco setup:   dependent source: /Applications/Racket/racket/share/pkgs/opengl/opengl/compiled/readspec_rkt.zo
raco setup:   used module: (lib "srfi/13.rkt")
raco setup: --- summary of missing dependencies ---
raco setup: undeclared dependency detected
raco setup:   for package: "opengl"
raco setup:   on package:
raco setup:    "srfi-lite-lib"
make[1]: **\* [plain-in-place] Error 1
make: **\* [in-place] Error 2

This should fix that.
