### PR TITLE
Fix/workaround procedure loading on some windows machines

### DIFF
--- a/opengl/main.rkt
+++ b/opengl/main.rkt
@@ -29,10 +29,12 @@
           (delay 
             (case stype
               [(windows)
+               (define lib (ffi-lib "opengl32"))
+               (define GetProcAddr (load-get-proc-address lib '("GetProcAddress")))
+               (define wglGetProcAddr (load-get-proc-address lib '("wglGetProcAddress")))
                (λ (name)
-                 (define lib (ffi-lib "opengl32"))
-                 (or ((load-get-proc-address lib '("GetProcAddress")) name)
-                     ((load-get-proc-address lib '("wglGetProcAddress")) name)))]
+                 (or (GetProcAddr name)
+                     (wglGetProcAddr name)))]
               [(macosx)
                (load-get-proc-address (ffi-lib "/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL")
                                       '())]

--- a/opengl/main.rkt
+++ b/opengl/main.rkt
@@ -29,8 +29,10 @@
           (delay 
             (case stype
               [(windows)
-               (load-get-proc-address (ffi-lib "opengl32") 
-                                      '("wglGetProcAddress"))]
+               (λ (name)
+                 (define lib (ffi-lib "opengl32"))
+                 (or ((load-get-proc-address lib '("GetProcAddress")) name)
+                     ((load-get-proc-address lib '("wglGetProcAddress")) name)))]
               [(macosx)
                (load-get-proc-address (ffi-lib "/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL")
                                       '())]


### PR DESCRIPTION
This change makes opengl stuff work on some windows machines.  It uses the same strategy (call GetProcAddress, then wglGetProcAddress) that pict3d used to workaround the same issue:
https://github.com/ntoronto/pict3d/issues/9

I believe this will solve the problem Leif was having:
https://github.com/stephanh42/RacketGL/issues/20

This fixed mode-lambda for me on one windows machine.  On a second windows machine that was always working, this did not cause any regression that I could see.

Please let me know if there's anything else I can do.  Thanks!
Dave